### PR TITLE
Support non-ASCII HTML

### DIFF
--- a/lib/Email/MIME/CreateHTML.pm
+++ b/lib/Email/MIME/CreateHTML.pm
@@ -129,14 +129,17 @@ sub parts_for_objects {
 
 sub build_html_email {
 	my($header, $html, $body_attributes, $html_mime_parts, $plain_text_mime) = @_;
-	
+
+	$body_attributes->{charset} = 'UTF-8' unless exists $body_attributes->{charset};
+	$body_attributes->{encoding}= 'quoted-printable' unless exists $body_attributes->{encoding};
+
 	my $email;
 	if ( ! scalar(@$html_mime_parts) && ! defined($plain_text_mime) ) {
 		# HTML, no embedded objects, no text alternative
 		$email = Email::MIME->create(
 			header => $header,
 			attributes => $body_attributes,
-			body => $html,
+			body_str => $html,
 		);
 	}
 	elsif ( ! scalar(@$html_mime_parts) && defined($plain_text_mime) ) {
@@ -148,7 +151,7 @@ sub build_html_email {
 				$plain_text_mime,
 				Email::MIME->create(
 					attributes => $body_attributes,
-					body => $html,
+					body_str => $html,
 				),
 			],
 		);
@@ -161,7 +164,7 @@ sub build_html_email {
 			parts => [
 				Email::MIME->create(
 					attributes => $body_attributes,
-					body => $html,
+					body_str => $html,
 				),
 				@$html_mime_parts,
 			],
@@ -179,7 +182,7 @@ sub build_html_email {
 					parts => [
 						Email::MIME->create(
 							attributes => $body_attributes,
-							body => $html,
+							body_str => $html,
 						),
 						@$html_mime_parts,
 					],

--- a/t/Email-MIME-CreateHTML.t
+++ b/t/Email-MIME-CreateHTML.t
@@ -270,6 +270,7 @@ sub test_mime {
 		my $got_body;
 
 		$exp_body =~ s/\s+$//g;
+		$exp_body =~ s/(?<!\r)\n/\r\n/g; # MIME mandates CRLF line endings in all encodings except binary
 
 		if(defined $mime) {
 		    $got_body = $mime->body;

--- a/t/UTF-8_html.t
+++ b/t/UTF-8_html.t
@@ -1,0 +1,80 @@
+use common::sense;
+
+use Email::Address;
+use Email::MIME::CreateHTML;
+use Encode;
+use FindBin qw($Bin);
+use HTML::TreeBuilder::XPath;
+use LWP::UserAgent;
+use MIME::Parser;
+use MIME::Words qw(encode_mimeword);
+use Test::More;
+
+my $builder = Test::More->builder;
+binmode $builder->output,         ":encoding(UTF-8)";
+binmode $builder->failure_output, ":encoding(UTF-8)";
+binmode $builder->todo_output,    ":encoding(UTF-8)";
+
+my $response = LWP::UserAgent->new->get("file://$Bin/data/UTF-8.html");
+
+my $body = $response->decoded_content;
+
+my $from = generate_address('Föö', 'test@foo.example');
+my $to   = generate_address('Bäz', 'test@baz.example');
+
+my $subject = encode_mimeword(encode_utf8('Sübject'), 'Q', 'UTF-8');
+
+my $mail = Email::MIME->create_html(
+    header => [
+        From    => $from->format,
+        To      => $to->format,
+        Subject => $subject,
+    ],
+    body            => $body,
+    body_attributes => {
+        charset  => 'UTF-8',
+        encoding => 'quoted-printable',
+    }
+);
+
+my $parsed_mail = parse_mail($mail->as_string);
+
+is(decode_utf8($parsed_mail->{from}), 'Föö <test@foo.example>');
+is(decode_utf8($parsed_mail->{to}),   'Bäz <test@baz.example>');
+is(decode_utf8($parsed_mail->{subject}), 'Sübject');
+
+is(decode_utf8($parsed_mail->{content}->findnodes('//p')->[0]->as_text), 'Umlaute: äöüßÄÖÜ');
+
+
+done_testing();
+
+sub generate_address {
+    my ($name, $address) = @_;
+
+    return Email::Address->new(
+        encode_mimeword(encode_utf8($name), 'Q', 'UTF-8'),
+        encode_utf8($address)
+    );
+}
+
+sub parse_mail {
+    my ($mail) = @_;
+
+    my $parser = MIME::Parser->new();
+    $parser->output_to_core(1);
+
+    my $parsed_mail = $parser->parse_data($mail);
+
+    my $subject = MIME::Words::decode_mimewords( $parsed_mail->head->get('Subject') );
+    my $from    = MIME::Words::decode_mimewords( $parsed_mail->head->get('From') );
+    my $to      = MIME::Words::decode_mimewords( $parsed_mail->head->get('To') );
+
+    defined and chomp foreach ($subject, $from, $to);
+
+    return {
+        content => HTML::TreeBuilder::XPath->new_from_content($parsed_mail->bodyhandle->as_string),
+        subject => $subject,
+        from    => $from,
+        to      => $to,
+    };
+}

--- a/t/data/UTF-8.html
+++ b/t/data/UTF-8.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+        <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+        <title>Testnewsletter</title>
+    </head>
+    <body>
+        <h1>Testnewsletter</h1>
+        <p>Umlaute: äöüßÄÖÜ</p>
+    </body>
+</html>


### PR DESCRIPTION
Downloaded HTML is parsed using HTML::TokeParser which decodes the HTML into
a Perl Unicode string. When serializing it back into a MIME body, it has to
be encoded again in a binary encoding. UTF-8 seems to be a safe choice that
can be overridden by the user by providing a charset in the $body_attributes.
