### PR TITLE
Use File::Slurper to read files

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,7 +32,7 @@ Test::Assertions::TestScript  = 0
 Email::MIME::Creator          = 0
 HTML::TokeParser::Simple      = 3.15
 HTML::Tagset                  = 0
-File::Slurp::WithinPolicy     = 0
+File::Slurper                 = 0
 MIME::Types                   = 2.17
 Data::Serializer              = 0
 

--- a/lib/Email/MIME/CreateHTML/Resolver/Filesystem.pm
+++ b/lib/Email/MIME/CreateHTML/Resolver/Filesystem.pm
@@ -8,7 +8,7 @@ package Email::MIME::CreateHTML::Resolver::Filesystem;
 
 use strict;
 use URI::file;
-use File::Slurp::WithinPolicy 'read_file';
+use File::Slurper 'read_binary';
 use MIME::Types;
 use File::Spec;
 
@@ -33,7 +33,7 @@ sub get_resource {
 	my $fullpath = defined($base_dir) ? File::Spec->catfile($base_dir,$path) : $path;
 
 	#Read in the file 
-	my $content = read_file($fullpath);
+	my $content = read_binary($fullpath);
 	my ($volume,$directories,$filename) = File::Spec->splitpath( $path );
 	
 	#Deduce MIME type/transfer encoding (currently using extension)


### PR DESCRIPTION
File::Slurp is discouraged due to [fundamental issues](http://blogs.perl.org/users/leon_timmermans/2015/08/fileslurp-is-broken-and-wrong.html). File::Slurper provides an easy to understand API particularly for reading binary files where no layers should be applied. This should resolve https://rt.cpan.org/Ticket/Display.html?id=127130