### PR TITLE
Email::MIME->create crashes with "Invalid Content-Type 'subtype' parameter"

### DIFF
--- a/lib/Email/MIME/CreateHTML/Resolver/LWP.pm
+++ b/lib/Email/MIME/CreateHTML/Resolver/LWP.pm
@@ -66,9 +66,8 @@ sub get_resource {
 
 	#If we have a content-type header we can make a more informed guess at MIME type
 	if ($response->header('content-type')) {
-		$mimetype = $response->header('content-type');
+		$mimetype = $response->content_type;
 		TRACE("Content Type header: $mimetype");
-		$mimetype = $1 if($mimetype =~ /(\S+);\s*charset=(.*)$/); #strip down to just a MIME type
 	}
 	
 	#If all else fails then some conservative and general-purpose defaults are:


### PR DESCRIPTION
This code:

``` perl
use strict;
use warnings;
use Email::MIME::CreateHTML;
use LWP::UserAgent;

my $uri = 'https://www.w3.org/';
my $html = LWP::UserAgent->new->get($uri)->decoded_content;
print Email::MIME->create_html(
        header => [
                From => 'my@address',
                To => 'your@address',
                Subject => 'Here is the information you requested',
        ],
        body => $html,
        base => $uri,
)->as_string;
```

crashes with this message:

``` code
Invalid Content-Type 'subtype' parameter at /usr/local/perl/lib/site_perl/5.32.1/Email/MIME/CreateHTML.pm line 113.
```

The cause is an embedded content that gives content-type as below:

``` bash
$ curl -I https://www.w3.org/2008/site/images/icons/rss30
HTTP/1.1 200 OK
...
content-type: image/png; qs=0.7
...
```
This PR may fix it.
